### PR TITLE
Fix duplicate import in converter

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -21,7 +21,6 @@ CHANGE LOG (2025-06):
 from pathlib import Path
 import subprocess, shutil, time, urllib.request
 import sys
-from pathlib import Path
 
 # Insert _after_ "import torch" but before any usage of load_depth_anything()
 # so that we can import DepthAnything from the cloned repo.


### PR DESCRIPTION
## Summary
- remove the repeated `from pathlib import Path` statement so there's only one

## Testing
- `python -m py_compile converter.py`


------
https://chatgpt.com/codex/tasks/task_e_68434e66c588832485af25ccd19cb7c8